### PR TITLE
Update links

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -81,7 +81,7 @@ Contributors wanted! Currently in Beta!">
                         <p>Sharing the stories of Soviet Citizens and insights into daily life within the Soviet Union, Sphere of Influence aims to cast the USSR in a positive light and share its culture with a modern audience. The project hopes to shatter illusions that the <a href="https://en.wikipedia.org/wiki/Criticism_of_capitalism">current state of society</a> is a fixed absolute, by offering a window through which to admire an alternative model.</p>
 <p>Sphere of Influence is built and maintained by volunteers in their spare time, it is a project of love.
 We are currently in Beta so things might be a little rough &amp; ready. </p>
-<p>Current editors are <a href="//twitter.com/sovietarchitect">@sovietarchitect</a> and <a href="//twitter.com/OldNewStandard">@OldNewStandard</a>, with assistance of family and friends.</p>
+<p>Current editors are <a href="//twitter.com/sovietarchitect">@sovietarchitect</a> and <a href="//github.com/bogstandard">Bogstandard</a>, with assistance of family and friends.</p>
 <hr>
 <h2 id="under-the-bonnet">Under the bonnet</h2>
 <p>Sphere of Influence pulls all its content from Twitter, the contributor accounts are listed on the main feed, these accounts post frequently, so there&#39;s almost always new tweets waiting for visitors.</p>
@@ -90,10 +90,10 @@ We are currently in Beta so things might be a little rough &amp; ready. </p>
 <h2 id="the-stack">The Stack</h2>
 <p>Sphere of Influence uses GitHub Pages for hosting the front-end and Heroku for providing the back-end. Open Layers and Open Street Map provide the mapping interface technology. Chiefly written in JavaScript and Python. There&#39;s a little caching going on so we don&#39;t max out the Twitter API.</p>
 <p>We&#39;re not using a framework on the front-end (eg. Vue, React) for a few reasons; 1) OpenLayers and Twitter are already overhead heavy. 2) This is an exercise in roll-your-own minimalism. 3) It&#39;s nice to have a break. For full technical details you can read the <a href="https://github.com/sphere-of-influence/sphere-of-influence">source code on GitHub</a>.</p>
-<p>Sphere of Influence is a lite rebuild of <a href="//twitter.com/OldNewStandard">@OldNewStandard</a>&#39;s <a href="https://folio.brighton.ac.uk/user/eric-daddio/atlaski-stories-mapped">Atlaski Project</a> for the University of Brighton.</p>
+<p>Sphere of Influence is a lite rebuild of <a href="//github.com/bogstandard">Bogstandard</a>&#39;s <a href="https://folio.brighton.ac.uk/user/eric-daddio/atlaski-stories-mapped">Atlaski Project</a> for the University of Brighton.</p>
 <hr>
 <h2 id="get-in-touch">Get in touch</h2>
-<p>Current editors are <a href="//twitter.com/sovietarchitect">@sovietarchitect</a> and <a href="//twitter.com/OldNewStandard">@OldNewStandard</a>. If you&#39;d like to join the team, help out or just curious please contact either of us.</p>
+<p>Current editors are <a href="//twitter.com/sovietarchitect">@sovietarchitect</a> and <a href="//github.com/bogstandard">Bogstandard</a>. If you&#39;d like to join the team, help out or just curious please contact either of us.</p>
 <p>If you are serious about contributing to the project please read the <a href="/pages/contributing.html">Contributors Guide</a>.</p>
 <p><script>
 function makeMail() {

--- a/src-pages/content/about.md
+++ b/src-pages/content/about.md
@@ -9,7 +9,7 @@ Sharing the stories of Soviet Citizens and insights into daily life within the S
 Sphere of Influence is built and maintained by volunteers in their spare time, it is a project of love.
 We are currently in Beta so things might be a little rough & ready. 
 
-Current editors are [@sovietarchitect](//twitter.com/sovietarchitect) and [@OldNewStandard](//twitter.com/OldNewStandard), with assistance of family and friends.
+Current editors are [@sovietarchitect](//twitter.com/sovietarchitect) and [Bogstandard](//github.com/bogstandard), with assistance of family and friends.
 
 ___
 
@@ -25,12 +25,12 @@ Sphere of Influence uses GitHub Pages for hosting the front-end and Heroku for p
 
 We're not using a framework on the front-end (eg. Vue, React) for a few reasons; 1) OpenLayers and Twitter are already overhead heavy. 2) This is an exercise in roll-your-own minimalism. 3) It's nice to have a break. For full technical details you can read the [source code on GitHub](https://github.com/sphere-of-influence/sphere-of-influence).
 
-Sphere of Influence is a lite rebuild of [@OldNewStandard](//twitter.com/OldNewStandard)'s [Atlaski Project](https://folio.brighton.ac.uk/user/eric-daddio/atlaski-stories-mapped) for the University of Brighton.
+Sphere of Influence is a lite rebuild of [Bogstandard](//github.com/bogstandard)'s [Atlaski Project](https://folio.brighton.ac.uk/user/eric-daddio/atlaski-stories-mapped) for the University of Brighton.
 
 ___
 
 ## Get in touch
-Current editors are [@sovietarchitect](//twitter.com/sovietarchitect) and [@OldNewStandard](//twitter.com/OldNewStandard). If you'd like to join the team, help out or just curious please contact either of us.
+Current editors are [@sovietarchitect](//twitter.com/sovietarchitect) and [Bogstandard](//github.com/bogstandard). If you'd like to join the team, help out or just curious please contact either of us.
 
 If you are serious about contributing to the project please read the [Contributors Guide](/pages/contributing.html).
 


### PR DESCRIPTION
My Twitter has become somewhat unprofessional and comprises the appearance of the site. This moves the links to my GitHub profile instead.